### PR TITLE
feat: 按断点调整硬盘面板与移动端布局

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: tad-module-${{ replace(github.ref_name, '/', '-') }}
+          name: tad-module-${{ github.run_id }}
           path: |
             tad-module.fpk
             tad-module.fpk.sha256

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: tad-module-${{ github.ref_name }}
+          name: tad-module-${{ replace(github.ref_name, '/', '-') }}
           path: |
             tad-module.fpk
             tad-module.fpk.sha256

--- a/app/ui/static/app.js
+++ b/app/ui/static/app.js
@@ -175,25 +175,58 @@ function renderStorageTable(storage = {}) {
   body.replaceChildren();
   slots.forEach((slot) => {
     const row = document.createElement('tr');
+    const empty = slot.state === 'empty';
     row.className = `storage-${slot.state || 'unknown'}`;
     const label = slot.kind === 'front' ? `前置 ${slot.slot}` : `M.2 ${slot.slot}`;
-    const deviceDetail = [slot.device, slot.model, slot.serial, formatSize(slot.size_bytes)].filter(Boolean).join(' · ');
-    const values = [
-      label,
-      STORAGE_STATE_LABELS[slot.state] || slot.state || '未知',
-      slot.state === 'empty' ? '—' : (STORAGE_ACTIVITY_LABELS[slot.activity] || slot.activity || '未知'),
-      deviceDetail || '—',
-      slot.purpose || (slot.state === 'empty' ? '空仓位' : '—'),
-      slot.warning || slot.health || '—',
-      formatTemperature(slot.temperature_c, Number(slot.temperature_c) > 0),
+    const stateLabel = STORAGE_STATE_LABELS[slot.state] || slot.state || '未知';
+    const activityLabel = empty ? '—' : (STORAGE_ACTIVITY_LABELS[slot.activity] || slot.activity || '未知');
+    const purposeLabel = slot.purpose || (empty ? '空仓位' : '—');
+    const healthLabel = slot.warning || slot.health || '—';
+    const temperature = formatTemperature(slot.temperature_c, Number(slot.temperature_c) > 0);
+    const model = slot.model || '—';
+    const meta = [slot.device, formatSize(slot.size_bytes), slot.serial].filter(Boolean).join(' · ') || '—';
+    const extra = [activityLabel, purposeLabel].filter((value) => value && value !== '—').join(' · ') || '—';
+    const cells = [
+      ['th', '仓位', 'storage-col-slot', label],
+      ['td', '状态', 'storage-col-state', stateLabel],
+      ['td', '活动', 'storage-col-activity', activityLabel],
+      ['td', '设备', 'storage-col-device', null],
+      ['td', '用途', 'storage-col-purpose', purposeLabel],
+      ['td', '健康', 'storage-col-health', healthLabel],
+      ['td', '温度', 'storage-col-temp', temperature],
     ];
-    const labels = ['仓位', '状态', '活动', '设备', '用途', '健康', '温度'];
-    values.forEach((value, index) => {
-      const cell = document.createElement(index === 0 ? 'th' : 'td');
-      cell.dataset.label = labels[index];
-      cell.textContent = value;
+    cells.forEach(([tag, name, className, value]) => {
+      const cell = document.createElement(tag);
+      cell.dataset.label = name;
+      cell.className = className;
+      if (className === 'storage-col-device') {
+        if (empty) {
+          cell.textContent = '—';
+        } else {
+          const wrap = document.createElement('div');
+          wrap.className = 'storage-device';
+          const title = document.createElement('span');
+          title.className = 'storage-model';
+          title.textContent = model;
+          const detail = document.createElement('small');
+          detail.className = 'storage-device-meta';
+          detail.textContent = meta;
+          const more = document.createElement('small');
+          more.className = 'storage-device-extra';
+          more.textContent = extra;
+          wrap.append(title, detail, more);
+          cell.append(wrap);
+        }
+      } else {
+        cell.textContent = value;
+      }
       row.append(cell);
     });
+    const cardHead = document.createElement('td');
+    cardHead.className = 'storage-card-head';
+    cardHead.dataset.label = '仓位';
+    cardHead.textContent = empty ? `${label} · ${stateLabel}` : `${label} · ${stateLabel} · ${temperature}`;
+    row.append(cardHead);
     body.append(row);
   });
   if (!slots.length) {

--- a/app/ui/static/index.html
+++ b/app/ui/static/index.html
@@ -68,7 +68,7 @@
             <div id="storage-visual" class="storage-visual" aria-label="硬盘机箱槽位图"></div>
             <div class="table-scroll">
               <table class="status-table storage-table">
-                <thead><tr><th>仓位</th><th>状态</th><th>活动</th><th>设备</th><th>用途</th><th>健康</th><th>温度</th></tr></thead>
+                <thead><tr><th class="storage-col-slot">仓位</th><th class="storage-col-state">状态</th><th class="storage-col-activity">活动</th><th class="storage-col-device"><span class="storage-head-device">设备</span><span class="storage-head-model">型号</span></th><th class="storage-col-purpose">用途</th><th class="storage-col-health">健康</th><th class="storage-col-temp">温度</th></tr></thead>
                 <tbody id="storage-body"></tbody>
               </table>
             </div>

--- a/app/ui/static/styles.css
+++ b/app/ui/static/styles.css
@@ -476,7 +476,7 @@ small {
   gap: clamp(18px, 3vw, 44px);
   align-items: flex-start;
   justify-content: start;
-  width: 100%;
+  width: auto;
   max-width: 1100px;
   margin-top: 4px;
   overflow: hidden;
@@ -783,8 +783,9 @@ small {
 
 .curve-chart {
   display: block;
-  width: 100%;
+  width: auto;
   max-width: 1100px;
+  margin-right: auto;
   min-height: 220px;
   aspect-ratio: 640 / 260;
   border: 1px solid #e2e5ea;
@@ -1259,10 +1260,19 @@ button.danger {
   .about-features,
   .field-grid { grid-template-columns: 1fr 1fr; }
   .fan-overview { grid-column: 1 / -1; min-width: 0; }
+  .app-layout { grid-template-columns: 152px minmax(0, 1fr); }
   .storage-visual {
     grid-template-columns: minmax(0, 1fr);
     gap: 12px;
-    max-width: none;
+    justify-items: start;
+    width: auto;
+    max-width: 1100px;
+  }
+  .storage-visual-group { width: auto; max-width: 100%; }
+  .curve-chart {
+    width: auto;
+    max-width: 1100px;
+    margin-right: auto;
   }
   .storage-table .storage-col-activity,
   .storage-table .storage-col-purpose { display: none; }
@@ -1349,7 +1359,6 @@ button.danger {
     width: 100%;
     grid-template-columns: 1fr 1fr;
   }
-  .curve-chart { width: 100%; max-width: none; }
   .panel-heading,
   .script-editor-footer,
   .curve-toolbar { flex-direction: column; align-items: flex-start; }

--- a/app/ui/static/styles.css
+++ b/app/ui/static/styles.css
@@ -475,7 +475,9 @@ small {
   grid-template-columns: minmax(0, 52fr) minmax(0, 43fr);
   gap: clamp(18px, 3vw, 44px);
   align-items: flex-start;
-  justify-content: stretch;
+  justify-content: start;
+  width: 100%;
+  max-width: 1100px;
   margin-top: 4px;
   overflow: hidden;
 }
@@ -545,12 +547,23 @@ small {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  min-width: 0;
+  overflow: hidden;
   padding: 4px;
   pointer-events: none;
 }
 
+.storage-slot-text b,
+.storage-slot-text span,
+.storage-slot-text small {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
+}
 .storage-slot-text b { color: #3e4551; font-size: 11px; }
-.storage-slot-text span { color: #353b45; font-size: 11px; font-weight: 700; white-space: nowrap; }
+.storage-slot-text span { color: #353b45; font-size: 11px; font-weight: 700; }
 .storage-slot-text small { margin: 3px 0 0; color: #606978; font-size: 9px; }
 
 .storage-visual-slot.tone-red .storage-slot-text span,
@@ -620,6 +633,27 @@ small {
 .storage-table th:nth-child(3), .storage-table td:nth-child(3) { width: 56px; }
 .storage-table th:nth-child(6), .storage-table td:nth-child(6) { width: 72px; }
 .storage-table th:nth-child(7), .storage-table td:nth-child(7) { width: 72px; }
+.storage-table .storage-col-device {
+  width: auto;
+  min-width: 0;
+  overflow: hidden;
+}
+.storage-device {
+  min-width: 0;
+  overflow: hidden;
+}
+.storage-model,
+.storage-device-meta,
+.storage-device-extra {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.storage-device-extra,
+.storage-card-head,
+.storage-head-model { display: none; }
 
 .inline-status {
   min-height: 16px;
@@ -750,7 +784,7 @@ small {
 .curve-chart {
   display: block;
   width: 100%;
-  max-width: none;
+  max-width: 1100px;
   min-height: 220px;
   aspect-ratio: 640 / 260;
   border: 1px solid #e2e5ea;
@@ -1218,16 +1252,34 @@ button.danger {
 
 .message.error { color: var(--danger); }
 
-@media (max-width: 980px) {
+@media (max-width: 1023px) {
   .overview-grid,
   .device-stats,
   .diagnostic-grid,
   .about-features,
   .field-grid { grid-template-columns: 1fr 1fr; }
   .fan-overview { grid-column: 1 / -1; min-width: 0; }
+  .storage-visual {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+    max-width: none;
+  }
+  .storage-table .storage-col-activity,
+  .storage-table .storage-col-purpose { display: none; }
+  .storage-head-device { display: none; }
+  .storage-head-model { display: inline; }
+  .storage-device-meta { display: none; }
+  .storage-device-extra { display: block; }
+  .storage-model {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 599px) {
   .app-layout {
     grid-template-columns: 1fr;
     grid-template-rows: auto minmax(0, 1fr);
@@ -1290,14 +1342,14 @@ button.danger {
   .device-stats,
   .field-grid,
   .diagnostic-grid,
-  .about-features,
-  .power-modes { grid-template-columns: 1fr; }
+  .about-features { grid-template-columns: 1fr; }
   .fan-overview { grid-column: auto; }
-  .storage-visual {
-    grid-template-columns: minmax(0, 52fr) minmax(0, 43fr);
-    gap: 8px;
+  .power-modes {
+    display: grid;
+    width: 100%;
+    grid-template-columns: 1fr 1fr;
   }
-  .curve-chart { width: 100%; }
+  .curve-chart { width: 100%; max-width: none; }
   .panel-heading,
   .script-editor-footer,
   .curve-toolbar { flex-direction: column; align-items: flex-start; }
@@ -1307,4 +1359,88 @@ button.danger {
   .debug-actions { flex-direction: row; align-items: stretch; }
   .debug-actions button { flex: 1 1 calc(50% - 8px); min-width: 0; }
   .debug-report { min-height: 280px; }
+
+  .storage-panel .table-scroll,
+  .gpio-editor .table-scroll { overflow: visible; }
+  .storage-table,
+  .storage-table tbody { display: block; width: 100%; }
+  .storage-table thead { display: none; }
+  .storage-table tbody tr {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 8px;
+    align-items: flex-start;
+    margin: 0 0 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+  .storage-table tbody tr:last-child { margin-bottom: 0; }
+  .storage-table tbody th,
+  .storage-table tbody td {
+    padding: 0;
+    border-bottom: 0;
+  }
+  .storage-card-head {
+    display: block;
+    flex: 1 1 100%;
+    order: 0;
+    color: #303641;
+    font-weight: 650;
+  }
+  .storage-col-slot,
+  .storage-col-state,
+  .storage-col-temp { display: none; }
+  .storage-col-device {
+    display: block;
+    flex: 1 1 100%;
+    order: 1;
+    width: auto;
+  }
+  .storage-table .storage-col-activity { order: 2; }
+  .storage-table .storage-col-purpose { order: 3; }
+  .storage-table .storage-col-health { order: 4; }
+  .storage-device-extra { display: none; }
+  .storage-device-meta { display: block; }
+  .storage-table .storage-col-activity,
+  .storage-table .storage-col-purpose,
+  .storage-table .storage-col-health {
+    display: inline-flex;
+    padding: 4px 8px;
+    border: 1px solid #e0e3e8;
+    border-radius: 6px;
+    background: #fff;
+  }
+  .storage-empty .storage-col-device,
+  .storage-empty .storage-col-activity,
+  .storage-empty .storage-col-purpose,
+  .storage-empty .storage-col-health { display: none; }
+
+  .gpio-table,
+  .gpio-table tbody { display: block; width: 100%; }
+  .gpio-table thead { display: none; }
+  .gpio-table tr {
+    display: block;
+    margin: 0 0 8px;
+    padding: 12px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+  .gpio-table tr:last-child { margin-bottom: 0; }
+  .gpio-table th,
+  .gpio-table td {
+    display: block;
+    width: 100%;
+    padding: 6px 0;
+    border-bottom: 0;
+  }
+  .gpio-table td::before {
+    content: attr(data-label);
+    display: block;
+    margin-bottom: 4px;
+    color: var(--muted);
+    font-size: 11px;
+  }
 }


### PR DESCRIPTION
## Summary
- 桌面（≥1024）保持现有侧栏、概览、SATA|M.2 并排仓位图和七列表；设备列改为两行：型号单行省略，次行 `设备 · 容量 · 序列号`，避免长型号挤扁邻列。
- `600–1023` 仓位图上下全宽叠放，磁盘表改为五列（仓位|状态|型号|健康|温度），活动/用途放在型号次行。
- `<600` 一盘一卡（仓位 · 状态 · 温度；型号最多两行；次行设备信息；底栏活动/用途/健康），空仓一行；按键映射三卡×四下拉，功耗模式 2×2。
- 槽内文案去掉 nowrap，长词不溢出。用 600/1024 替换 980/720。未改 API、文案、版本或仓位 SVG。

## Test plan
- [ ] 桌面 ≥1024：侧栏 152px、概览两列、仓位图左右并排、七列表；长型号 `Western Digital Red Plus WD80EFPX-68C9ZN0 8TB` 与 `Samsung SSD 990 PRO 2TB MZ-V9P2T0B/AM` 不撑破邻列。
- [ ] 桌面视觉与现界面一致，没有新侧栏、CPU 条、sparkline、抽屉箭头。
- [ ] 768：五列表 + 仓位图上下全宽，长型号两行省略。
- [ ] 390：一盘一卡、仓位图上下排、空仓一行；按键三卡四下拉、功耗 2×2。
- [ ] 现有 980/720 媒体查询已不存在。
