### PR TITLE
fix: 手机图表、关于页状态和仓位色

### DIFF
--- a/app/ui/static/app.js
+++ b/app/ui/static/app.js
@@ -189,11 +189,11 @@ function renderStorageTable(storage = {}) {
     const cells = [
       ['th', '仓位', 'storage-col-slot', label],
       ['td', '状态', 'storage-col-state', stateLabel],
-      ['td', '活动', 'storage-col-activity', activityLabel],
+      ['td', '活动', `storage-col-activity activity-${slot.activity || 'unknown'}`, activityLabel],
       ['td', '设备', 'storage-col-device', null],
       ['td', '用途', 'storage-col-purpose', purposeLabel],
       ['td', '健康', 'storage-col-health', healthLabel],
-      ['td', '温度', 'storage-col-temp', temperature],
+      ['td', '温度', `storage-col-temp${storageIsHot(slot) ? ' is-hot' : ''}`, temperature],
     ];
     cells.forEach(([tag, name, className, value]) => {
       const cell = document.createElement(tag);
@@ -250,11 +250,6 @@ function initializeStorageVisual() {
   STORAGE_VISUAL_GROUPS.forEach((group) => {
     const figure = document.createElement('figure');
     figure.className = `storage-visual-group storage-visual-${group.kind}`;
-    if (group.kind === 'm2') {
-      const caption = document.createElement('figcaption');
-      caption.textContent = '内置 M.2 插槽';
-      figure.append(caption);
-    }
     const frame = document.createElement('div');
     frame.className = 'storage-visual-frame';
     const base = document.createElement('img');
@@ -262,6 +257,11 @@ function initializeStorageVisual() {
     base.src = baseUrl(group.base);
     base.alt = group.kind === 'front' ? '六盘位机箱示意图' : '四个 M.2 槽位示意图';
     frame.append(base);
+    if (group.kind === 'm2') {
+      const caption = document.createElement('figcaption');
+      caption.textContent = '内置 M.2 插槽';
+      frame.append(caption);
+    }
     group.ids.forEach((id) => {
       const marker = document.createElement('div');
       marker.className = 'storage-visual-slot is-empty';
@@ -286,11 +286,38 @@ function initializeStorageVisual() {
   storageVisualReady = true;
 }
 
+function storageIsHot(slot = {}) {
+  const temp = Number(slot.temperature_c);
+  if (!(temp > 0)) return false;
+  return slot.kind === 'm2' ? temp >= 70 : temp >= 55;
+}
+
+function storageIsFault(slot = {}) {
+  return slot.state === 'warning' || /故障|告警|fail|critical|error/i.test(String(slot.warning || slot.health || ''));
+}
+
 function storageVisualTone(slot = {}) {
   if (slot.state === 'empty') return 'empty';
-  if (slot.state === 'warning' || slot.activity === 'busy') return 'red';
-  if (slot.state === 'present' || slot.activity === 'sleeping' || slot.state === 'unknown') return 'gray';
+  if (storageIsFault(slot) || storageIsHot(slot)) return 'red';
+  if (slot.activity === 'sleeping') return 'sleep';
+  if (slot.state === 'present' || slot.state === 'unknown') return 'unused';
   return 'green';
+}
+
+function connectedFans(fanStatus = {}) {
+  return (fanStatus.fans || []).filter((fan) => Number(fan.rpm) > 0).slice(0, 4);
+}
+
+function fanDisplayName(fan, fans) {
+  return fans.length === 1 ? 'FAN' : `FAN${fan.channel}`;
+}
+
+function markStat(id, bad, level = 'danger') {
+  const el = $(id);
+  if (!el) return;
+  el.classList.toggle('stat-box', Boolean(bad));
+  el.classList.toggle('danger', Boolean(bad) && level === 'danger');
+  el.classList.toggle('warn', Boolean(bad) && level === 'warn');
 }
 
 function renderStorageVisual(storage = {}) {
@@ -306,7 +333,8 @@ function renderStorageVisual(storage = {}) {
       if (tone === 'empty') {
         overlay.hidden = true;
       } else {
-        const source = baseUrl(group.assets[tone]);
+        const overlayTone = (tone === 'sleep' || tone === 'unused') ? 'gray' : tone;
+        const source = baseUrl(group.assets[overlayTone]);
         if (overlay.dataset.source !== source) {
           overlay.src = source;
           overlay.dataset.source = source;
@@ -1056,7 +1084,7 @@ function updateCurveFromPointer(kind, event) {
 
 function populateFanDevices(status, keepInputs) {
   const select = $('fan-device');
-  const fans = (status.fan_control?.fans || []).filter((fan) => Number(fan.rpm) > 0);
+  const fans = connectedFans(status.fan_control);
   const config = status.config?.fan || {};
   const signature = fans.map((fan) => fan.id).join('|');
   const rebuild = signature !== fanSelectorSignature;
@@ -1073,7 +1101,7 @@ function populateFanDevices(status, keepInputs) {
         input.type = 'checkbox';
         input.value = fan.id;
         const name = document.createElement('b');
-        name.textContent = `FAN${fan.channel}`;
+        name.textContent = fanDisplayName(fan, fans);
         const rpm = document.createElement('small');
         label.append(input, name, rpm);
         container.append(label);
@@ -1084,7 +1112,7 @@ function populateFanDevices(status, keepInputs) {
     fans.forEach((fan) => {
       const option = document.createElement('option');
       option.value = fan.id;
-      option.textContent = `FAN${fan.channel}`;
+      option.textContent = fanDisplayName(fan, fans);
       select.append(option);
     });
   }
@@ -1132,7 +1160,7 @@ function fillFanInputs(fan = {}) {
 
 function renderFanRPMs(fanStatus = {}) {
   const target = $('fan-rpm-list');
-  const fans = (fanStatus.fans || []).filter((fan) => Number(fan.rpm) >= 0).slice(0, 4);
+  const fans = connectedFans(fanStatus);
   const existing = [...target.querySelectorAll('[data-fan-id]')];
   if (existing.map((item) => item.dataset.fanId).join('|') !== fans.map((fan) => fan.id).join('|')) {
     target.replaceChildren();
@@ -1146,7 +1174,7 @@ function renderFanRPMs(fanStatus = {}) {
   }
   fans.forEach((fan) => {
     const item = target.querySelector(`[data-fan-id="${fan.id}"]`);
-    item.querySelector('span').textContent = `FAN${fan.channel}`;
+    item.querySelector('span').textContent = fanDisplayName(fan, fans);
     item.querySelector('strong').textContent = `${fan.rpm} RPM`;
   });
 }
@@ -1204,6 +1232,8 @@ function render(status, keepInputs = false) {
     : 'CPU 核心最高（RR 口径）';
   $('cpu-display-temperature').textContent = formatTemperature(cpuTemperature.display_c, cpuTemperature.available);
   $('package-temperature').textContent = formatTemperature(cpuTemperature.package_max_c, Number(cpuTemperature.package_sensors) > 0);
+  markStat('cpu-display-temperature', cpuTemperature.available && Number(cpuTemperature.display_c) >= 80);
+  markStat('package-temperature', Number(cpuTemperature.package_sensors) > 0 && Number(cpuTemperature.package_max_c) >= 90);
   $('current-pl1').textContent = pkg.has_pl1 ? `${pkg.pl1_w} W` : '不可用';
   $('current-pl2').textContent = pkg.has_pl2 ? `${pkg.pl2_w} W` : '不可用';
   renderFanRPMs(fanStatus);
@@ -1228,6 +1258,10 @@ function render(status, keepInputs = false) {
   const healthy = issues.length === 0;
   $('health').textContent = healthy ? '运行正常' : '需要检查';
   $('health').className = `badge ${healthy ? 'ok' : 'error'}`;
+  if ($('about-health')) {
+    $('about-health').textContent = healthy ? '运行正常' : '需要检查';
+    $('about-health').className = healthy ? 'ok' : 'danger';
+  }
   const healthMessage = healthy
     ? '未发现需要处理的异常。'
     : `需要检查以下项目：\n${issues.map((issue) => `• ${issue}`).join('\n')}`;
@@ -1377,6 +1411,10 @@ async function refresh(keepInputs = false) {
     $('health').textContent = '连接失败';
     $('health').className = 'badge error';
     $('health-tooltip').textContent = `无法读取模块状态：${error.message}`;
+    if ($('about-health')) {
+      $('about-health').textContent = '连接失败';
+      $('about-health').className = 'danger';
+    }
   }
 }
 

--- a/app/ui/static/index.html
+++ b/app/ui/static/index.html
@@ -313,6 +313,7 @@
                 <h2>TAD6S4N模块</h2>
                 <p>为 TANK TAD6S4N 机型定制，其它硬件目前未做完整适配。</p>
                 <p class="about-version-line">当前版本 <strong id="about-version">v—</strong></p>
+                <p class="about-health-line">运行状态 <strong id="about-health">—</strong></p>
               </div>
             </div>
             <div class="about-features">

--- a/app/ui/static/styles.css
+++ b/app/ui/static/styles.css
@@ -438,10 +438,11 @@ small {
 .temperature-pair p { margin: 0; }
 .temperature-pair b { font-size: 18px; }
 
-.fan-overview { min-width: 148px; }
+.fan-overview { min-width: 0; width: 100%; }
 
 .fan-rpm-list {
   display: grid;
+  width: 100%;
   gap: 6px;
 }
 
@@ -488,7 +489,7 @@ small {
   margin: 0;
 }
 
-.storage-visual-front { padding-top: 30px; }
+.storage-visual-front { padding-top: 0; }
 
 .storage-visual-group figcaption {
   height: 22px;
@@ -498,6 +499,18 @@ small {
   font-weight: 700;
   line-height: 22px;
   text-align: center;
+}
+
+.storage-visual-m2 figcaption {
+  position: absolute;
+  left: 50%;
+  top: 16%;
+  z-index: 2;
+  height: auto;
+  margin: 0;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  white-space: nowrap;
 }
 
 .storage-visual-frame {
@@ -622,11 +635,26 @@ small {
 }
 
 .status-table tbody th { color: #303641; font-weight: 650; white-space: nowrap; }
-.status-table .storage-empty td { color: #a0a5af; }
+.status-table .storage-empty td { color: #7b8290; }
 .status-table .storage-present td:nth-child(2) { color: #2f86bc; font-weight: 650; }
 .status-table .storage-used td:nth-child(2) { color: var(--success); font-weight: 650; }
 .status-table .storage-warning td:nth-child(2),
-.status-table .storage-warning td:nth-child(6) { color: var(--danger); font-weight: 650; }
+.status-table .storage-warning td:nth-child(6),
+.status-table .storage-col-temp.is-hot { color: var(--danger); font-weight: 650; }
+.status-table .storage-col-activity.activity-idle { color: #3d4654; font-weight: 650; }
+.status-table .storage-col-activity.activity-sleeping { color: #2a7ab0; font-weight: 650; }
+.status-table .storage-col-activity.activity-busy { color: #3d4654; font-weight: 650; }
+
+.storage-visual-slot.tone-sleep .storage-slot-overlay { filter: sepia(.28) hue-rotate(175deg) saturate(.9); }
+.storage-visual-slot.tone-unused .storage-slot-overlay { filter: saturate(.25) brightness(1.06); }
+
+.stat-box {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: 6px;
+}
+.stat-box.warn { color: #9a5b00; background: #fff4e0; }
+.stat-box.danger { color: var(--danger); background: #fff1f0; }
 
 .storage-table th:nth-child(1), .storage-table td:nth-child(1) { width: 72px; }
 .storage-table th:nth-child(2), .storage-table td:nth-child(2) { width: 64px; }
@@ -707,8 +735,14 @@ small {
 
 .diagnostic-chip b { color: #475065; font-size: 11px; white-space: nowrap; }
 .diagnostic-chip.ok, .diagnostic-ok { color: var(--success); }
-.diagnostic-chip.muted { color: var(--muted); }
-.diagnostic-chip.warning, .diagnostic-error { color: var(--danger); }
+.diagnostic-chip.muted { color: #5c6470; }
+.diagnostic-chip.warning, .diagnostic-error {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: 6px;
+  color: var(--danger);
+  background: #fff1f0;
+}
 
 .notice {
   margin: 0;
@@ -783,9 +817,9 @@ small {
 
 .curve-chart {
   display: block;
-  width: auto;
-  max-width: 1100px;
-  margin-right: auto;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   min-height: 220px;
   aspect-ratio: 640 / 260;
   border: 1px solid #e2e5ea;
@@ -1103,6 +1137,8 @@ small {
 .about-heading img { width: 168px; max-height: 118px; object-fit: contain; }
 .about-heading h2 { font-size: 22px; }
 .about-heading p { margin: 0; color: var(--muted); font-size: 13px; }
+.about-health-line strong.ok { color: var(--success); }
+.about-health-line strong.danger { color: var(--danger); }
 .about-version-line { margin-top: 8px !important; }
 .about-version-line strong { color: var(--text); font-weight: 700; }
 
@@ -1270,9 +1306,9 @@ button.danger {
   }
   .storage-visual-group { width: auto; max-width: 100%; }
   .curve-chart {
-    width: auto;
-    max-width: 1100px;
-    margin-right: auto;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
   }
   .storage-table .storage-col-activity,
   .storage-table .storage-col-purpose { display: none; }
@@ -1330,15 +1366,13 @@ button.danger {
     text-overflow: ellipsis;
   }
   .app-tabs button > img { flex-shrink: 0; }
-  .sidebar-meta {
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: center;
-    margin-top: 6px;
-    min-width: 0;
-    overflow: hidden;
-  }
-  .sidebar-meta .health-summary { margin-left: auto; }
+  .sidebar-meta { display: none; }
+  .app-sidebar { max-height: 72px; }
+  .curve-chart,
+  .storage-visual,
+  .storage-visual-group,
+  .device-identity img { max-width: 100%; }
+  .tab-form { overflow-x: hidden; }
   .health-tooltip {
     top: 116px;
     right: 12px;


### PR DESCRIPTION
按用户清单：
1. 手机曲线/仓位图 max-width 100%，不超界
2. 手机不显示侧栏版本号和运行正常，挪到关于页
3. 异常值（高温、诊断错误）加色底
4. 「内置 M.2 插槽」叠在图上居中
5. PC 曲线和转速列表宽度跟容器走
6. 只有一个风扇时显示 FAN，隐藏无转速接口
空闲字加深；仓位繁忙不红，红只留给故障/高温；休眠和未启用用灰图加滤镜区分。底图未换。