### PR TITLE
fix: 修复代码审查发现的 7 处利用率采样与面板显示问题

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -39,6 +39,7 @@ jobs:
           go test ./...
           go vet ./...
           node --check app/ui/static/app.js
+          node --test app/ui/static/app.test.js
           bash -n cmd/* scripts/build.sh
 
       - name: Download official fnpack

--- a/app/ui/static/app.js
+++ b/app/ui/static/app.js
@@ -253,13 +253,21 @@ function storageSlotStatusLabel(slot = {}, tone = '') {
   if (isStorageHot(slot)) return '高温';
   if (slot.state === 'present') return '未使用';
   if (slot.state === 'unknown') return STORAGE_STATE_LABELS.unknown;
+  // used 只代表"已使用"，不等于 SMART 健康；无活动读数时回退状态标签。
   return STORAGE_ACTIVITY_LABELS[slot.activity]
-    || (slot.state === 'used' ? '健康' : (STORAGE_STATE_LABELS[slot.state] || STORAGE_STATE_LABELS.unknown));
+    || STORAGE_STATE_LABELS[slot.state]
+    || STORAGE_STATE_LABELS.unknown;
 }
 
 function connectedFans(fanStatus = {}, limit = 0) {
   const fans = (fanStatus.fans || []).filter((fan) => Number(fan.rpm) >= 0);
   return limit > 0 ? fans.slice(0, limit) : fans;
+}
+
+// 选择器签名只由风扇集合决定、与转速无关：瞬时 0 转（停转或故障保护）
+// 不会触发列表重建，未保存的勾选因此不会丢。
+function fanListSignature(fans = []) {
+  return fans.map((fan) => fan.id).join('|');
 }
 
 function fanLabel(fan, fans = []) {
@@ -1253,7 +1261,7 @@ function populateFanDevices(status, keepInputs) {
   const select = $('fan-device');
   const fans = connectedFans(status.fan_control);
   const config = status.config?.fan || {};
-  const signature = fans.map((fan) => fan.id).join('|');
+  const signature = fanListSignature(fans);
   const rebuild = signature !== fanSelectorSignature;
   if (rebuild) {
     fanSelectorSignature = signature;

--- a/app/ui/static/app.js
+++ b/app/ui/static/app.js
@@ -247,8 +247,18 @@ function storageTempTone(slot = {}) {
   return isStorageHot(slot) ? 'danger' : 'temp';
 }
 
+function storageSlotStatusLabel(slot = {}, tone = '') {
+  if (tone === 'empty') return '空置';
+  if (slot.state === 'warning') return STORAGE_STATE_LABELS.warning;
+  if (isStorageHot(slot)) return '高温';
+  if (slot.state === 'present') return '未使用';
+  if (slot.state === 'unknown') return STORAGE_STATE_LABELS.unknown;
+  return STORAGE_ACTIVITY_LABELS[slot.activity]
+    || (slot.state === 'used' ? '健康' : (STORAGE_STATE_LABELS[slot.state] || STORAGE_STATE_LABELS.unknown));
+}
+
 function connectedFans(fanStatus = {}, limit = 0) {
-  const fans = (fanStatus.fans || []).filter((fan) => Number(fan.rpm) > 0);
+  const fans = (fanStatus.fans || []).filter((fan) => Number(fan.rpm) >= 0);
   return limit > 0 ? fans.slice(0, limit) : fans;
 }
 
@@ -475,23 +485,10 @@ function renderStorageVisual(storage = {}) {
       } else {
         temperature.textContent = formatTemperature(slot.temperature_c);
       }
-      const statusLabel = tone === 'empty'
-        ? '空置'
-        : (slot.state === 'warning'
-          ? '告警'
-          : (isStorageHot(slot)
-            ? '高温'
-            : (slot.state === 'present'
-              ? '未使用'
-              : (STORAGE_ACTIVITY_LABELS[slot.activity] || ''))));
       if (status) {
-        if (group.kind === 'm2') {
-          status.textContent = tone === 'empty'
-            ? '空置'
-            : (STORAGE_ACTIVITY_LABELS[slot.activity] || '');
-        } else {
-          status.textContent = compact ? '' : statusLabel;
-        }
+        status.textContent = compact && group.kind === 'front'
+          ? ''
+          : storageSlotStatusLabel(slot, tone);
       }
     });
   });

--- a/app/ui/static/app.test.js
+++ b/app/ui/static/app.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+// 回归测试（node:test，无第三方依赖）：通过 vm 在最小 DOM/定时器桩中加载
+// 真实的 app.js，对纯逻辑函数做断言。运行：node --test app/ui/static/
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function stubElement() {
+  const store = { checked: false, value: '', textContent: '' };
+  return new Proxy(function stub() {}, {
+    get(_target, prop) {
+      if (prop === Symbol.toPrimitive || prop === 'toString') return () => '';
+      if (prop in store) return store[prop];
+      return stubElement();
+    },
+    set(_target, prop, value) {
+      store[prop] = value;
+      return true;
+    },
+    apply() {
+      return stubElement();
+    },
+  });
+}
+
+function loadAppContext() {
+  const source = fs.readFileSync(path.join(__dirname, 'app.js'), 'utf8');
+  const matchMedia = () => ({ matches: false, addEventListener() {} });
+  const sandbox = {
+    console,
+    URLSearchParams,
+    setInterval: () => 0,
+    clearInterval: () => {},
+    setTimeout: () => 0,
+    clearTimeout: () => {},
+    requestAnimationFrame: () => 0,
+    fetch: () => new Promise(() => {}),
+    Image: function Image() {},
+    ResizeObserver: class ResizeObserver {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    },
+    navigator: { userAgent: 'node-test' },
+    location: { reload() {}, href: '', pathname: '/' },
+    document: {
+      readyState: 'complete',
+      getElementById: () => stubElement(),
+      createElement: () => stubElement(),
+      createElementNS: () => stubElement(),
+      createTextNode: () => stubElement(),
+      querySelector: () => stubElement(),
+      querySelectorAll: () => [],
+      addEventListener() {},
+      body: stubElement(),
+      documentElement: stubElement(),
+    },
+  };
+  sandbox.window = {
+    matchMedia,
+    addEventListener() {},
+    innerWidth: 1280,
+    innerHeight: 800,
+    location: sandbox.location,
+  };
+  sandbox.globalThis = sandbox;
+  const context = vm.createContext(sandbox);
+  vm.runInContext(source, context, { filename: 'app.js' });
+  return (name) => vm.runInContext(name, context);
+}
+
+const resolve = loadAppContext();
+
+test('盘位覆盖层标签：empty/present/used/warning/unknown 各状态文案统一', () => {
+  const storageSlotStatusLabel = resolve('storageSlotStatusLabel');
+  assert.equal(storageSlotStatusLabel({ state: 'empty' }, 'empty'), '空置');
+  assert.equal(storageSlotStatusLabel({ state: 'present' }), '未使用');
+  assert.equal(storageSlotStatusLabel({ state: 'used', activity: 'working' }), '工作');
+  assert.equal(storageSlotStatusLabel({ state: 'used', activity: 'idle' }), '空闲');
+  assert.equal(storageSlotStatusLabel({ state: 'used', activity: 'sleeping' }), '休眠');
+  assert.equal(storageSlotStatusLabel({ state: 'warning' }), '告警');
+  assert.equal(storageSlotStatusLabel({ state: 'unknown' }), '未知');
+});
+
+test('盘位覆盖层标签：used 无活动读数显示"已使用"，不得伪装成 SMART 健康', () => {
+  const storageSlotStatusLabel = resolve('storageSlotStatusLabel');
+  assert.equal(storageSlotStatusLabel({ state: 'used', activity: 'unknown' }), '未知');
+  assert.equal(storageSlotStatusLabel({ state: 'used' }), '已使用');
+});
+
+test('盘位覆盖层标签：高温优先于活动状态，前置与 M.2 阈值各自生效', () => {
+  const storageSlotStatusLabel = resolve('storageSlotStatusLabel');
+  const isStorageHot = resolve('isStorageHot');
+  assert.equal(storageSlotStatusLabel({ state: 'used', kind: 'front', temperature_c: 56, activity: 'idle' }), '高温');
+  assert.equal(storageSlotStatusLabel({ state: 'used', kind: 'm2', temperature_c: 71, activity: 'idle' }), '高温');
+  assert.equal(isStorageHot({ kind: 'front', temperature_c: 55 }), true);
+  assert.equal(isStorageHot({ kind: 'm2', temperature_c: 70 }), true);
+  assert.equal(isStorageHot({ kind: 'front', temperature_c: 54.9 }), false);
+  assert.equal(isStorageHot({ kind: 'm2', temperature_c: 69.9 }), false);
+});
+
+test('风扇 1200→0→1200：选择器签名不变，未保存的勾选不触发重建', () => {
+  const fanListSignature = resolve('fanListSignature');
+  const fans = (rpm) => [
+    { id: 'fan0', channel: 0, rpm },
+    { id: 'fan1', channel: 1, rpm },
+  ];
+  const baseline = fanListSignature(fans(1200));
+  assert.equal(fanListSignature(fans(0)), baseline);
+  assert.equal(fanListSignature(fans(1200)), baseline);
+  assert.equal(baseline, 'fan0|fan1');
+  assert.notEqual(fanListSignature([{ id: 'fan0' }, { id: 'fan2' }]), baseline);
+});
+
+test('风扇 1200→0→1200：0 RPM 风扇保持可见，负值仍被过滤', () => {
+  const connectedFans = resolve('connectedFans');
+  const fans = [
+    { id: 'fan0', channel: 0, rpm: 1200 },
+    { id: 'fan1', channel: 1, rpm: 0 },
+    { id: 'fan2', channel: 2, rpm: -1 },
+  ];
+  const visible = connectedFans({ fans });
+  assert.deepEqual(visible.map((fan) => fan.id), ['fan0', 'fan1']);
+  assert.equal(connectedFans({ fans: [{ id: 'fan1', rpm: 0 }] }).length, 1);
+});

--- a/internal/powerguard/storage.go
+++ b/internal/powerguard/storage.go
@@ -163,8 +163,10 @@ func (m *Manager) StorageStatus() StorageStatus {
 }
 
 // RefreshStorageActivity 由 2 秒后台循环调用，是共享采样时间线的唯一写入者：
-// sysfs 读取在锁外完成，锁内只合并结果，不做文件 I/O；合并时重新校验目标
-// 仓位仍持有采样时的设备且未在期间进入休眠，避免与全量扫描竞态错写。
+// sysfs 读取在锁外完成，锁内只合并结果，不做文件 I/O。休眠盘也参与采样——
+// 读 /sys/class/block/*/stat 只是内核计数、不会唤醒硬盘，且保证唤醒前后
+// 时间线连续（Δ 窗口不被休眠时长稀释）；合并时重新校验仓位仍持有采样时的
+// 设备，避免与全量扫描竞态错写。
 func (m *Manager) RefreshStorageActivity() {
 	type target struct {
 		id, kname string
@@ -173,7 +175,7 @@ func (m *Manager) RefreshStorageActivity() {
 	targets := make([]target, 0, len(m.storageStatus.Slots))
 	for index := range m.storageStatus.Slots {
 		slot := &m.storageStatus.Slots[index]
-		if slot.Device == "" || slot.State == StorageEmpty || slot.Activity == StorageActivitySleeping {
+		if slot.Device == "" || slot.State == StorageEmpty {
 			continue
 		}
 		targets = append(targets, target{id: slot.ID, kname: filepath.Base(slot.Device)})
@@ -194,17 +196,26 @@ func (m *Manager) RefreshStorageActivity() {
 	defer m.storageMu.Unlock()
 	for index := range m.storageStatus.Slots {
 		slot := &m.storageStatus.Slots[index]
-		if slot.Device == "" || slot.State == StorageEmpty || slot.Activity == StorageActivitySleeping {
+		if slot.Device == "" || slot.State == StorageEmpty {
 			continue
 		}
 		for _, item := range results {
 			if item.id == slot.ID && item.kname == filepath.Base(slot.Device) {
-				slot.Activity = item.activity
-				slot.Utilization = item.utilization
+				slot.Activity, slot.Utilization = mergeStorageActivity(slot.Activity, item.activity, item.utilization)
 				break
 			}
 		}
 	}
+}
+
+// mergeStorageActivity 合并循环采样结果：休眠中的盘 io_ticks 冻结、只会
+// 采出空闲，没有 I/O 证据（工作/繁忙）时保留"休眠"标签；静默唤醒（盘转
+// 起来了但暂无 I/O）由全量扫描按 SMART 电源模式清除。
+func mergeStorageActivity(current, sampled string, utilization *float64) (string, *float64) {
+	if current == StorageActivitySleeping && sampled != StorageActivityWorking && sampled != StorageActivityBusy {
+		return current, nil
+	}
+	return sampled, utilization
 }
 
 func cloneStorageStatus(status StorageStatus) StorageStatus {
@@ -322,6 +333,11 @@ func (m *Manager) collectStorage(forceSMART bool) StorageStatus {
 		slot.TemperatureC = result.TemperatureC
 		if powerModeIsSleeping(result.PowerMode) {
 			slot.Activity = StorageActivitySleeping
+			slot.Utilization = nil
+		} else if slot.Activity == StorageActivitySleeping {
+			// 静默唤醒（盘已转起但暂无 I/O 证据）：清掉过期的休眠标记，
+			// 活动循环下一拍会重新给出真实忙闲。
+			slot.Activity = StorageActivityUnknown
 			slot.Utilization = nil
 		}
 		slot.Health = "正常"

--- a/internal/powerguard/storage.go
+++ b/internal/powerguard/storage.go
@@ -30,8 +30,8 @@ const (
 	StorageActivitySleeping = "sleeping"
 	StorageActivityUnknown  = "unknown"
 
-	storageIdleUtilMax    = 0.0
-	storageWorkingUtilMax = 70.0
+	storageWorkingUtilMax    = 70.0
+	storageWorkingDisplayMin = 0.5
 )
 
 type StorageSlot struct {
@@ -127,16 +127,11 @@ type smartResult struct {
 }
 
 type blockIOSample struct {
-	Reads      uint64
-	Writes     uint64
-	ReadTicks  uint64
-	WriteTicks uint64
-	IOTicks    uint64
-	InFlight   uint64
-	StallCount int
-	SampledAt  time.Time
-	Util       float64
-	HasUtil    bool
+	IOTicks   uint64
+	InFlight  uint64
+	SampledAt time.Time
+	Util      float64
+	HasUtil   bool
 }
 
 var blockIOStates sync.Map
@@ -152,7 +147,6 @@ func (m *Manager) RefreshStorage(forceSMART bool) StorageStatus {
 }
 
 func (m *Manager) StorageStatus() StorageStatus {
-	m.RefreshStorageActivity()
 	m.storageMu.RLock()
 	defer m.storageMu.RUnlock()
 	status := cloneStorageStatus(m.storageStatus)
@@ -568,7 +562,8 @@ func activityFromUtilization(util float64) string {
 	if util > storageWorkingUtilMax {
 		return StorageActivityBusy
 	}
-	if util > storageIdleUtilMax {
+	// 低于 0.5 的繁忙度经前端 Math.round 显示为 0%，按 README 约定归为空闲。
+	if util >= storageWorkingDisplayMin {
 		return StorageActivityWorking
 	}
 	return StorageActivityIdle
@@ -619,23 +614,21 @@ func (m *Manager) readBlockActivity(kname, kind string) (string, *float64) {
 	if len(fields) < 10 {
 		return StorageActivityUnknown, nil
 	}
-	reads, readErr := strconv.ParseUint(fields[0], 10, 64)
-	writes, writeErr := strconv.ParseUint(fields[4], 10, 64)
-	readTicks, readTickErr := strconv.ParseUint(fields[3], 10, 64)
-	writeTicks, writeTickErr := strconv.ParseUint(fields[7], 10, 64)
 	inFlight, flightErr := strconv.ParseUint(fields[8], 10, 64)
 	ioTicks, ioTickErr := strconv.ParseUint(fields[9], 10, 64)
-	if readErr != nil || writeErr != nil || readTickErr != nil || writeTickErr != nil || flightErr != nil || ioTickErr != nil {
+	if flightErr != nil || ioTickErr != nil {
 		return StorageActivityUnknown, nil
 	}
 	sample := blockIOSample{
-		Reads: reads, Writes: writes, ReadTicks: readTicks, WriteTicks: writeTicks,
 		IOTicks: ioTicks, InFlight: inFlight, SampledAt: time.Now(),
 	}
 	previous, hadPrevious := loadBlockIO(kname)
 	_ = kind
 	if !hadPrevious {
 		storeBlockIO(kname, sample)
+		if inFlight > 0 {
+			return StorageActivityBusy, nil
+		}
 		return StorageActivityIdle, nil
 	}
 	if util := storageUtilization(previous, sample); util != nil {

--- a/internal/powerguard/storage.go
+++ b/internal/powerguard/storage.go
@@ -128,7 +128,6 @@ type smartResult struct {
 
 type blockIOSample struct {
 	IOTicks   uint64
-	InFlight  uint64
 	SampledAt time.Time
 	Util      float64
 	HasUtil   bool
@@ -163,7 +162,34 @@ func (m *Manager) StorageStatus() StorageStatus {
 	return status
 }
 
+// RefreshStorageActivity 由 2 秒后台循环调用，是共享采样时间线的唯一写入者：
+// sysfs 读取在锁外完成，锁内只合并结果，不做文件 I/O；合并时重新校验目标
+// 仓位仍持有采样时的设备且未在期间进入休眠，避免与全量扫描竞态错写。
 func (m *Manager) RefreshStorageActivity() {
+	type target struct {
+		id, kname string
+	}
+	m.storageMu.RLock()
+	targets := make([]target, 0, len(m.storageStatus.Slots))
+	for index := range m.storageStatus.Slots {
+		slot := &m.storageStatus.Slots[index]
+		if slot.Device == "" || slot.State == StorageEmpty || slot.Activity == StorageActivitySleeping {
+			continue
+		}
+		targets = append(targets, target{id: slot.ID, kname: filepath.Base(slot.Device)})
+	}
+	m.storageMu.RUnlock()
+
+	type result struct {
+		id, kname, activity string
+		utilization         *float64
+	}
+	results := make([]result, 0, len(targets))
+	for _, item := range targets {
+		activity, utilization := m.readBlockActivity(item.kname)
+		results = append(results, result{id: item.id, kname: item.kname, activity: activity, utilization: utilization})
+	}
+
 	m.storageMu.Lock()
 	defer m.storageMu.Unlock()
 	for index := range m.storageStatus.Slots {
@@ -171,13 +197,34 @@ func (m *Manager) RefreshStorageActivity() {
 		if slot.Device == "" || slot.State == StorageEmpty || slot.Activity == StorageActivitySleeping {
 			continue
 		}
-		slot.Activity, slot.Utilization = m.readBlockActivity(filepath.Base(slot.Device), slot.Kind)
+		for _, item := range results {
+			if item.id == slot.ID && item.kname == filepath.Base(slot.Device) {
+				slot.Activity = item.activity
+				slot.Utilization = item.utilization
+				break
+			}
+		}
 	}
 }
 
 func cloneStorageStatus(status StorageStatus) StorageStatus {
 	status.Slots = append([]StorageSlot(nil), status.Slots...)
 	return status
+}
+
+// cachedStorageActivity 供全量扫描继承后台循环已缓存的忙闲状态：扫描本身
+// 不再推进共享采样时间线，避免与 2 秒循环交叠采样破坏 Δ 窗口。仓位换了
+// 盘或尚无缓存时返回未知，等待循环下一拍填充。
+func (m *Manager) cachedStorageActivity(id, kname string) (string, *float64) {
+	m.storageMu.RLock()
+	defer m.storageMu.RUnlock()
+	for index := range m.storageStatus.Slots {
+		slot := &m.storageStatus.Slots[index]
+		if slot.ID == id && slot.Device != "" && filepath.Base(slot.Device) == kname {
+			return slot.Activity, slot.Utilization
+		}
+	}
+	return StorageActivityUnknown, nil
 }
 
 func (m *Manager) collectStorage(forceSMART bool) StorageStatus {
@@ -248,7 +295,7 @@ func (m *Manager) collectStorage(forceSMART bool) StorageStatus {
 			slot.State = StorageUsed
 		}
 		slot.Purpose = strings.Join(info.Purposes, "、")
-		slot.Activity, slot.Utilization = m.readBlockActivity(kname, spec.Kind)
+		slot.Activity, slot.Utilization = m.cachedStorageActivity(spec.ID, kname)
 		if warning := m.mdWarning(info.Purposes); warning != "" {
 			slot.State = StorageWarning
 			slot.Warning = warning
@@ -605,7 +652,9 @@ func utilizationPointer(sample blockIOSample) *float64 {
 	return &value
 }
 
-func (m *Manager) readBlockActivity(kname, kind string) (string, *float64) {
+// readBlockActivity 只由后台活动循环调用（见 RefreshStorageActivity）。
+// 首个样本没有 Δ 窗口，按空闲处理、不给出利用率，下一拍起才有读数。
+func (m *Manager) readBlockActivity(kname string) (string, *float64) {
 	data, err := os.ReadFile(filepath.Join(m.rooted("/sys/class/block"), kname, "stat"))
 	if err != nil {
 		return StorageActivityUnknown, nil
@@ -614,21 +663,16 @@ func (m *Manager) readBlockActivity(kname, kind string) (string, *float64) {
 	if len(fields) < 10 {
 		return StorageActivityUnknown, nil
 	}
-	inFlight, flightErr := strconv.ParseUint(fields[8], 10, 64)
 	ioTicks, ioTickErr := strconv.ParseUint(fields[9], 10, 64)
-	if flightErr != nil || ioTickErr != nil {
+	if ioTickErr != nil {
 		return StorageActivityUnknown, nil
 	}
 	sample := blockIOSample{
-		IOTicks: ioTicks, InFlight: inFlight, SampledAt: time.Now(),
+		IOTicks: ioTicks, SampledAt: time.Now(),
 	}
 	previous, hadPrevious := loadBlockIO(kname)
-	_ = kind
 	if !hadPrevious {
 		storeBlockIO(kname, sample)
-		if inFlight > 0 {
-			return StorageActivityBusy, nil
-		}
 		return StorageActivityIdle, nil
 	}
 	if util := storageUtilization(previous, sample); util != nil {

--- a/internal/powerguard/storage_test.go
+++ b/internal/powerguard/storage_test.go
@@ -254,7 +254,7 @@ func sampleUtil(t *testing.T, manager *Manager, path, kname, line string, elapse
 		storeBlockIO(kname, sample)
 	}
 	writeBlockStat(t, path, line)
-	return manager.readBlockActivity(kname, "front")
+	return manager.readBlockActivity(kname)
 }
 
 func TestReadBlockActivityUsesUtilizationBands(t *testing.T) {
@@ -302,7 +302,7 @@ func TestReadBlockActivityUtilizationMatchesDiskstatsUtil(t *testing.T) {
 	}
 	manager := &Manager{Root: root}
 	writeBlockStat(t, statPath, "1 0 8 2 3 0 9 4 0 100 0\n")
-	if _, util := manager.readBlockActivity("sda", "front"); util != nil {
+	if _, util := manager.readBlockActivity("sda"); util != nil {
 		t.Fatalf("first sample should not have utilization, got %v", *util)
 	}
 	sample, ok := loadBlockIO("sda")
@@ -312,7 +312,7 @@ func TestReadBlockActivityUtilizationMatchesDiskstatsUtil(t *testing.T) {
 	sample.SampledAt = sample.SampledAt.Add(-time.Second)
 	storeBlockIO("sda", sample)
 	writeBlockStat(t, statPath, "2 0 8 12 4 0 9 14 0 830 0\n")
-	got, util := manager.readBlockActivity("sda", "front")
+	got, util := manager.readBlockActivity("sda")
 	if util == nil {
 		t.Fatal("expected utilization")
 	}
@@ -333,12 +333,12 @@ func TestReadBlockActivityWorkingWhenUtilIsNonzero(t *testing.T) {
 	}
 	manager := &Manager{Root: root}
 	writeBlockStat(t, statPath, "10 0 8 2 3 0 9 4 0 100 0\n")
-	manager.readBlockActivity("sdb", "front")
+	manager.readBlockActivity("sdb")
 	sample, _ := loadBlockIO("sdb")
 	sample.SampledAt = sample.SampledAt.Add(-time.Second)
 	storeBlockIO("sdb", sample)
 	writeBlockStat(t, statPath, "10 0 8 2 3 0 9 4 0 170 0\n")
-	got, util := manager.readBlockActivity("sdb", "front")
+	got, util := manager.readBlockActivity("sdb")
 	if got != StorageActivityWorking {
 		t.Fatalf("util 7%% without new r/w: got %q, want working", got)
 	}
@@ -356,17 +356,23 @@ func containsString(values []string, want string) bool {
 	return false
 }
 
-func TestReadBlockActivityBusyOnFirstSampleWithInFlight(t *testing.T) {
-	resetBlockIOStates()
-	root := t.TempDir()
-	statPath := filepath.Join(root, "sys", "class", "block", "sdc", "stat")
-	if err := os.MkdirAll(filepath.Dir(statPath), 0o755); err != nil {
-		t.Fatal(err)
+func TestActivityFromUtilizationBoundaries(t *testing.T) {
+	cases := []struct {
+		util float64
+		want string
+		note string
+	}{
+		{0.4, StorageActivityIdle, "低于 0.5 经前端取整显示 0%，归空闲"},
+		{0.5, StorageActivityWorking, "0.5 恰好进入工作带"},
+		{0.51, StorageActivityWorking, "0.51 工作带"},
+		{70, StorageActivityWorking, "70 仍属工作带"},
+		{70.01, StorageActivityBusy, "刚超过 70 判繁忙"},
+		{100, StorageActivityBusy, "100 繁忙"},
 	}
-	manager := &Manager{Root: root}
-	got, util := sampleUtil(t, manager, statPath, "sdc", "1 0 8 2 3 0 9 4 7 100 0\n", 0)
-	if got != StorageActivityBusy || util != nil {
-		t.Fatalf("first sample with in-flight IO: got %q util %v, want busy and nil", got, util)
+	for _, item := range cases {
+		if got := activityFromUtilization(item.util); got != item.want {
+			t.Fatalf("activityFromUtilization(%.2f) = %q, want %q（%s）", item.util, got, item.want, item.note)
+		}
 	}
 }
 

--- a/internal/powerguard/storage_test.go
+++ b/internal/powerguard/storage_test.go
@@ -380,7 +380,7 @@ func TestReadBlockActivitySubHalfPercentIsIdle(t *testing.T) {
 	manager := &Manager{Root: root}
 	sampleUtil(t, manager, statPath, "sdd", "1 0 8 2 3 0 9 4 0 100 0\n", 0)
 	got, util := sampleUtil(t, manager, statPath, "sdd", "1 0 8 2 3 0 9 4 0 104 0\n", time.Second)
-	if got != StorageActivityIdle || util == nil || *util <= 0 || *util >= 0.5 {
-		t.Fatalf("0.4%% util: got %q util %v, want idle with 0 < util < 0.5", got, util)
+	if got != StorageActivityIdle || util == nil || *util != 0 {
+		t.Fatalf("0.4%% util: got %q util %v, want idle with util forced to 0", got, util)
 	}
 }

--- a/internal/powerguard/storage_test.go
+++ b/internal/powerguard/storage_test.go
@@ -400,6 +400,94 @@ func TestMergeStorageActivityPreservesSleepUntilIOEvidence(t *testing.T) {
 	}
 }
 
+func seededActivityManager(t *testing.T, statLine string) (*Manager, string) {
+	t.Helper()
+	resetBlockIOStates()
+	root := t.TempDir()
+	statPath := filepath.Join(root, "sys", "class", "block", "sda", "stat")
+	if err := os.MkdirAll(filepath.Dir(statPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeBlockStat(t, statPath, statLine)
+	return &Manager{Root: root}, statPath
+}
+
+func (m *Manager) seedSlot(t *testing.T, slot StorageSlot) {
+	t.Helper()
+	m.storageMu.Lock()
+	defer m.storageMu.Unlock()
+	m.storageStatus = StorageStatus{Slots: []StorageSlot{slot}}
+}
+
+func TestCachedStorageActivityCarriesOverOnlyForSameDevice(t *testing.T) {
+	manager, _ := seededActivityManager(t, "1 0 8 2 3 0 9 4 0 100 0\n")
+	util := 7.0
+	manager.seedSlot(t, StorageSlot{
+		ID: "front-1", Kind: "front", Slot: 1, State: StorageUsed,
+		Device: "/dev/sda", Activity: StorageActivityWorking, Utilization: &util,
+	})
+
+	if activity, got := manager.cachedStorageActivity("front-1", "sda"); activity != StorageActivityWorking || got == nil || *got != 7 {
+		t.Fatalf("cached carry-over = (%q, %v), want working/7", activity, got)
+	}
+	if activity, got := manager.cachedStorageActivity("front-1", "sdb"); activity != StorageActivityUnknown || got != nil {
+		t.Fatalf("device swap must not carry over, got (%q, %v)", activity, got)
+	}
+	if activity, got := manager.cachedStorageActivity("front-2", "sda"); activity != StorageActivityUnknown || got != nil {
+		t.Fatalf("unknown slot must not carry over, got (%q, %v)", activity, got)
+	}
+}
+
+func TestRefreshStorageActivityMergesWithoutLockHeldIO(t *testing.T) {
+	manager, statPath := seededActivityManager(t, "1 0 8 2 3 0 9 4 0 100 0\n")
+	manager.seedSlot(t, StorageSlot{
+		ID: "front-1", Kind: "front", Slot: 1, State: StorageUsed,
+		Device: "/dev/sda", Activity: StorageActivityUnknown,
+	})
+
+	manager.RefreshStorageActivity() // 首拍：无前序样本，写入时间线
+	if activity, util := manager.storageStatus.Slots[0].Activity, manager.storageStatus.Slots[0].Utilization; activity != StorageActivityIdle || util != nil {
+		t.Fatalf("first tick: got (%q, %v), want idle/nil", activity, util)
+	}
+
+	sample, ok := loadBlockIO("sda")
+	if !ok {
+		t.Fatal("timeline not seeded by first tick")
+	}
+	sample.SampledAt = sample.SampledAt.Add(-time.Second)
+	storeBlockIO("sda", sample)
+	writeBlockStat(t, statPath, "1 0 8 2 3 0 9 4 0 170 0\n")
+
+	manager.RefreshStorageActivity() // 第二拍：Δ=70ms io_ticks / 1s ≈ 7%
+	slot := manager.storageStatus.Slots[0]
+	if slot.Activity != StorageActivityWorking || slot.Utilization == nil || *slot.Utilization < 6 || *slot.Utilization > 8 {
+		t.Fatalf("second tick: got (%q, %v), want working ≈7%%", slot.Activity, slot.Utilization)
+	}
+}
+
+func TestRefreshStorageActivityPreservesSleepingUntilIO(t *testing.T) {
+	manager, statPath := seededActivityManager(t, "1 0 8 2 3 0 9 4 0 100 0\n")
+	manager.seedSlot(t, StorageSlot{
+		ID: "front-1", Kind: "front", Slot: 1, State: StorageUsed,
+		Device: "/dev/sda", Activity: StorageActivitySleeping,
+	})
+
+	manager.RefreshStorageActivity() // 休眠中 io_ticks 冻结 → 采出空闲 → 保留休眠
+	if activity, util := manager.storageStatus.Slots[0].Activity, manager.storageStatus.Slots[0].Utilization; activity != StorageActivitySleeping || util != nil {
+		t.Fatalf("sleeping slot: got (%q, %v), want sleeping/nil", activity, util)
+	}
+
+	sample, _ := loadBlockIO("sda") // 休眠期间时间线仍被推进（不丢更新）
+	sample.SampledAt = sample.SampledAt.Add(-time.Second)
+	storeBlockIO("sda", sample)
+	writeBlockStat(t, statPath, "1 0 8 2 3 0 9 4 0 880 0\n") // 唤醒后 78% I/O
+
+	manager.RefreshStorageActivity()
+	if activity := manager.storageStatus.Slots[0].Activity; activity != StorageActivityBusy {
+		t.Fatalf("woken slot with IO: got %q, want busy", activity)
+	}
+}
+
 func TestReadBlockActivitySubHalfPercentIsIdle(t *testing.T) {
 	resetBlockIOStates()
 	root := t.TempDir()

--- a/internal/powerguard/storage_test.go
+++ b/internal/powerguard/storage_test.go
@@ -355,3 +355,32 @@ func containsString(values []string, want string) bool {
 	}
 	return false
 }
+
+func TestReadBlockActivityBusyOnFirstSampleWithInFlight(t *testing.T) {
+	resetBlockIOStates()
+	root := t.TempDir()
+	statPath := filepath.Join(root, "sys", "class", "block", "sdc", "stat")
+	if err := os.MkdirAll(filepath.Dir(statPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manager := &Manager{Root: root}
+	got, util := sampleUtil(t, manager, statPath, "sdc", "1 0 8 2 3 0 9 4 7 100 0\n", 0)
+	if got != StorageActivityBusy || util != nil {
+		t.Fatalf("first sample with in-flight IO: got %q util %v, want busy and nil", got, util)
+	}
+}
+
+func TestReadBlockActivitySubHalfPercentIsIdle(t *testing.T) {
+	resetBlockIOStates()
+	root := t.TempDir()
+	statPath := filepath.Join(root, "sys", "class", "block", "sdd", "stat")
+	if err := os.MkdirAll(filepath.Dir(statPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manager := &Manager{Root: root}
+	sampleUtil(t, manager, statPath, "sdd", "1 0 8 2 3 0 9 4 0 100 0\n", 0)
+	got, util := sampleUtil(t, manager, statPath, "sdd", "1 0 8 2 3 0 9 4 0 104 0\n", time.Second)
+	if got != StorageActivityIdle || util == nil || *util <= 0 || *util >= 0.5 {
+		t.Fatalf("0.4%% util: got %q util %v, want idle with 0 < util < 0.5", got, util)
+	}
+}

--- a/internal/powerguard/storage_test.go
+++ b/internal/powerguard/storage_test.go
@@ -376,6 +376,30 @@ func TestActivityFromUtilizationBoundaries(t *testing.T) {
 	}
 }
 
+func TestMergeStorageActivityPreservesSleepUntilIOEvidence(t *testing.T) {
+	util := 7.0
+	cases := []struct {
+		current, sampled string
+		want             string
+		wantUtil         bool
+		note             string
+	}{
+		{StorageActivitySleeping, StorageActivityIdle, StorageActivitySleeping, false, "休眠中 io_ticks 冻结采出空闲，保留休眠"},
+		{StorageActivitySleeping, StorageActivityUnknown, StorageActivitySleeping, false, "采样读失败不覆盖休眠"},
+		{StorageActivitySleeping, StorageActivityWorking, StorageActivityWorking, true, "唤醒后出现 I/O 立即覆盖"},
+		{StorageActivitySleeping, StorageActivityBusy, StorageActivityBusy, true, "繁忙同样覆盖"},
+		{StorageActivityUnknown, StorageActivityIdle, StorageActivityIdle, true, "非休眠状态直接采用采样（idle 带 0% 指针也透传）"},
+		{StorageActivityIdle, StorageActivityWorking, StorageActivityWorking, true, "空闲→工作"},
+	}
+	for _, item := range cases {
+		got, utilOut := mergeStorageActivity(item.current, item.sampled, &util)
+		if got != item.want || (utilOut != nil) != item.wantUtil {
+			t.Fatalf("mergeStorageActivity(%q, %q) = (%q, util=%v), want %q util=%v（%s）",
+				item.current, item.sampled, got, utilOut, item.want, item.wantUtil, item.note)
+		}
+	}
+}
+
 func TestReadBlockActivitySubHalfPercentIsIdle(t *testing.T) {
 	resetBlockIOStates()
 	root := t.TempDir()


### PR DESCRIPTION
## 总述

**故障描述**
多轮代码审查确认、且在当前 main（v0.10.11）上仍然存在的问题集中在三类：存储活动采样架构（并发采样共享单样本时间线导致利用率失真、写锁内做文件 I/O）、风扇可见性（`rpm>0` 过滤隐藏 0 转故障风扇、瞬时 0 转冲掉未保存选择）、UI 口径一致性（"工作"配"0%"、仓位文案与标签表漂移、未知态空白文案）。

**修复方法**
按最小改动原则逐条修复，保持 README 既有契约与 0.10.x 语义、不引入新状态码。采样权属收敛到 2 秒后台循环：循环是共享时间线的**唯一写入者**，sysfs 读取全部在锁外，锁内只按"仓位 ID + 设备名"复核后合并；全量扫描只继承循环缓存的活动状态（`cachedStorageActivity`），不再推进时间线。

> 审查共确认 8 处问题，其中"图表标签极值偏移"已被上游 v0.10.9 的 `bff0708` 以含缩放感知的更优实现覆盖，rebase 时取上游版本，故本 PR 现含 **7 处**修复，基线 **v0.10.11**。

## 分述

1. **并发采样腐蚀利用率**（storage.go）：`/api/status` 单请求内两次毫秒间隔采样叠加独立 2 秒循环 → Δ 窗口坍缩、空闲/繁忙翻转，且全程持写锁做 N 次文件读。→ `StorageStatus` 恢复 RLock 纯克隆；`RefreshStorageActivity` 改为"锁外采样、锁内短合并"。休眠盘照常参与采样（读 `/sys/class/block/*/stat` 是内核计数、不会唤醒硬盘），保证唤醒前后时间线连续、Δ 窗口不被休眠时长稀释；无 I/O 证据时保留"休眠"标签（`mergeStorageActivity`），唤醒后出现 I/O 立即覆盖，静默唤醒由扫描按 SMART 电源模式清除。
2. **故障风扇消失**（app.js `connectedFans`）：可见性谓词由 `>=0` 误改为 `>0`，0 RPM 风扇从面板蒸发且幸存者被改名 FAN。→ 恢复 `>=0`。
3. **瞬时 0 转冲掉未保存选择**（app.js `populateFanDevices`）：签名随 rpm 抖动触发重建并回填服务器配置。→ 签名提取为 `fanListSignature()`，只由风扇集合决定、与转速无关。
4. **"工作"配"0%"**（storage.go `activityFromUtilization`）：后端用未取整浮点判级，前端 `Math.round` 把 <0.5% 显示成 0%。→ 新增 `storageWorkingDisplayMin=0.5`，低于 0.5 归空闲，与 README「0% 为空闲」一致。
5. **InFlight 死代码**（storage.go）：`fields[8]` 解析后从未使用。→ `blockIOSample` 瘦身至 {IOTicks, SampledAt, Util, HasUtil}；首拍没有 Δ 窗口，按空闲处理、不给出利用率（审查意见已撤回首拍 InFlight 判忙启发式）。
6. **仓位文案漂移**（app.js 盘位覆盖层）：五层嵌套三元重复实现 `STORAGE_STATE_LABELS` 且已漂移，M.2 分支丢弃计算结果重复取值。→ 新增 `storageSlotStatusLabel()`，由标签表派生、单点覆盖（高温/未使用），前仓与 M.2 共用。
7. **未知态空白文案**（同上）：回退链以 `|| ''` 结尾，State=unknown 且无活动时仓位文字为空；used 且无活动被写成「健康」而 used ≠ SMART 健康。→ 终端回退为 `STORAGE_STATE_LABELS.unknown`（"未知"）；used 无活动显示「已使用」。

第二个提交是对 #4 的测试收尾：`readBlockActivity` 对 idle 态强制 `*util = 0`，回归断言相应为 `*util == 0` 而非 0.4%。

## 验证

- 基于 v0.10.11：`go test ./...`、`go vet ./...`、`gofmt`、`bash -n` 全绿
- 新增 Go 测试：利用率分档边界（0.4/0.5/0.51/70/70.01/100）、休眠标签合并全路径、缓存继承仅限同仓位同设备、活动循环端到端（首拍建时间线→次拍出利用率→休眠保留→唤醒 I/O 覆盖）
- 新增 JS 回归 `app.test.js`（node:test + vm 桩加载真实 app.js，无第三方依赖，5 用例）：盘位标签 empty/present/used/warning/unknown 全状态矩阵（两种覆盖层共用同一函数）、used 无活动不伪装健康、高温阈值 SATA 55/M.2 70 边界、风扇 1200→0→1200 选择器签名不变、0 RPM 风扇保持可见；CI 已接入 `node --test`
- 保持项未动：`StorageStatus` 只读、0 RPM 可见、SATA/M.2 统一文案、图表钳制（上游 `bff0708` 版本）、manifest 未改


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 统一前置存储仓位与 M.2 仓位的状态显示文案。
  - 优化存储活动状态判断：低于 0.5% 利用率显示为空闲，并更准确地保留休眠状态及识别实际唤醒。
  - 风扇列表现在会保留转速为 0 RPM 的已连接风扇，瞬时转速变化不会导致列表频繁重建。

- **测试**
  - 增加存储状态、温度告警、风扇识别及活动状态判断的自动化回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->