### PR TITLE
fix(storage): 兼容 smartctl 7.5 的 object 型 power_mode

### DIFF
--- a/internal/powerguard/storage.go
+++ b/internal/powerguard/storage.go
@@ -1,6 +1,7 @@
 package powerguard
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -756,6 +757,40 @@ func (m *Manager) mdWarning(purposes []string) string {
 	return ""
 }
 
+// smartPowerMode accepts smartctl power_mode as a string ("STANDBY")
+// or as an object ({"ata_value":255,"name":"ACTIVE or IDLE"}) from smartctl 7.5+.
+type smartPowerMode struct {
+	raw string
+}
+
+func (m *smartPowerMode) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || string(b) == "null" {
+		m.raw = ""
+		return nil
+	}
+	switch b[0] {
+	case '"':
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		m.raw = s
+		return nil
+	case '{':
+		var o struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(b, &o); err != nil {
+			return err
+		}
+		m.raw = o.Name
+		return nil
+	default:
+		return fmt.Errorf("unsupported power_mode JSON: %s", string(b))
+	}
+}
+
 func findSmartctl() (string, error) {
 	for _, candidate := range []string{"/usr/sbin/smartctl", "/usr/bin/smartctl"} {
 		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
@@ -801,7 +836,7 @@ func parseSMART(data []byte) (smartResult, error) {
 			Temperature     float64 `json:"temperature"`
 			PercentageUsed  int64   `json:"percentage_used"`
 		} `json:"nvme_smart_health_information_log"`
-		PowerMode string `json:"power_mode"`
+		PowerMode smartPowerMode `json:"power_mode"`
 		Smartctl  struct {
 			ExitStatus int64 `json:"exit_status"`
 			Messages   []struct {
@@ -818,7 +853,7 @@ func parseSMART(data []byte) (smartResult, error) {
 	}
 	// smartctl -n standby reports sleeping drives via smartctl.messages
 	// ("Device is in STANDBY mode, exit(2)") rather than a power_mode field.
-	powerMode := strings.TrimSpace(document.PowerMode)
+	powerMode := strings.TrimSpace(document.PowerMode.raw)
 	if powerMode == "" {
 		for _, msg := range document.Smartctl.Messages {
 			lower := strings.ToLower(msg.String)

--- a/internal/powerguard/storage_test.go
+++ b/internal/powerguard/storage_test.go
@@ -192,6 +192,37 @@ func TestParseSMARTReportsStandbyPowerMode(t *testing.T) {
 	}
 }
 
+func TestParseSMARTAcceptsObjectPowerMode(t *testing.T) {
+	data := []byte(`{
+  "smart_status":{"passed":true},
+  "temperature":{"current":43},
+  "power_mode":{"ata_value":255,"name":"ACTIVE or IDLE"}
+}`)
+	result, err := parseSMART(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TemperatureC != 43 {
+		t.Fatalf("expected temperature 43, got %+v", result)
+	}
+	if result.PowerMode != "ACTIVE or IDLE" {
+		t.Fatalf("expected ACTIVE or IDLE power mode, got %+v", result)
+	}
+	if powerModeIsSleeping(result.PowerMode) {
+		t.Fatalf("ACTIVE or IDLE should not be sleeping, got %+v", result)
+	}
+}
+
+func TestParseSMARTObjectStandbyPowerMode(t *testing.T) {
+	result, err := parseSMART([]byte(`{"power_mode":{"ata_value":0,"name":"STANDBY"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.PowerMode != "STANDBY" || !powerModeIsSleeping(result.PowerMode) {
+		t.Fatalf("expected standby object power mode, got %+v", result)
+	}
+}
+
 func TestParseSMARTDetectsStandbyFromMessages(t *testing.T) {
 	data := []byte(`{
   "json_format_version": [1, 0],


### PR DESCRIPTION
## Summary
- smartctl 7.5 把 `power_mode` 输出成对象（`{"ata_value":255,"name":"ACTIVE or IDLE"}`），原先按 `string` 反序列化会失败，导致醒着的 SATA 盘温度读不到、`health=未读取`。
- `parseSMART` 改为兼容字符串与对象两种形态；对象取 `name`。
- 回归测试覆盖 ACTIVE/STANDBY 对象形态，并保留原有字符串形态用例。

Related to #17（reporter noerror6；亦在 #11 评论中报告）。

## Test plan
- [x] `go test ./internal/powerguard -count=1` 本地通过
- [x] CI 绿（https://github.com/luodaoyi/TAD6S4N10G-fnos/actions/runs/34012804446）
- [ ] 用 smartctl 7.5 的 SATA 盘确认 `storage.slots[].temperature_c` 有值、不再出现 `cannot unmarshal object into Go struct field .power_mode`